### PR TITLE
remove fallback date for `nextRunAt`

### DIFF
--- a/src/job/index.ts
+++ b/src/job/index.ts
@@ -213,7 +213,7 @@ class Job<T extends JobAttributesData = JobAttributesData> {
       name: attrs.name || '',
       priority: attrs.priority,
       type: type || 'once',
-      nextRunAt: nextRunAt || new Date(),
+      nextRunAt: nextRunAt,
     };
   }
 


### PR DESCRIPTION
This just creates wrong data. Old jobs that have been executed already and will not be executed again appear as jobs that will run at the current date (as their date is null). It should just be null instead like it is written in the persistence layer. No need for a fallback.

Is this behaviour important for some other logic?