### PR TITLE
Fix the resumeOnRestart function to handle correctl the recurring jobs + do not run finished non-recurrent jobs on restart + add unit tests

### DIFF
--- a/src/job/index.ts
+++ b/src/job/index.ts
@@ -186,7 +186,7 @@ class Job<T extends JobAttributesData = JobAttributesData> {
   attrs: JobAttributes<T>;
 
   constructor(options: Modify<JobAttributes<T>, { _id?: mongodb.ObjectId }>) {
-    const { pulse, type, nextRunAt, ...args } = options ?? {};
+    const { pulse, type, nextRunAt, repeatAt, repeatInterval, lastFinishedAt, ...args } = options ?? {};
 
     // Save Pulse instance
     this.pulse = pulse;
@@ -213,7 +213,10 @@ class Job<T extends JobAttributesData = JobAttributesData> {
       name: attrs.name || '',
       priority: attrs.priority,
       type: type || 'once',
-      nextRunAt: nextRunAt || new Date(),
+      // if a job that's non-recurring has a lastFinishedAt (finished the job), do not default nextRunAt to now
+      // only if it will be defaulted either by explicitly setting it or by computing it computeNextRunAt
+      nextRunAt:
+        repeatAt || repeatInterval ? nextRunAt || new Date() : !lastFinishedAt ? nextRunAt || new Date() : nextRunAt,
     };
   }
 

--- a/src/pulse/resume-on-restart.ts
+++ b/src/pulse/resume-on-restart.ts
@@ -1,5 +1,6 @@
 import createDebugger from 'debug';
 import { Pulse } from '.';
+import { Job } from '../job';
 
 const debug = createDebugger('pulse:resumeOnRestart');
 
@@ -18,6 +19,8 @@ export const resumeOnRestart: ResumeOnRestartMethod = function (this: Pulse, res
 
   if (this._collection && this._resumeOnRestart) {
     const now = new Date();
+
+    // Non-recurring jobs
     this._collection
       .updateMany(
         {
@@ -41,7 +44,48 @@ export const resumeOnRestart: ResumeOnRestartMethod = function (this: Pulse, res
       )
       .then((result) => {
         if (result.modifiedCount > 0) {
-          debug('resuming unfinished %d jobs(%s)', result.modifiedCount, now.toISOString());
+          debug('Resumed %d unfinished standard jobs (%s)', result.modifiedCount, now.toISOString());
+        }
+      });
+
+    // Handling for recurring jobs using repeatInterval or repeatAt
+    this._collection
+      .find({
+        $or: [{ repeatInterval: { $exists: true } }, { repeatAt: { $exists: true } }],
+        nextRunAt: { $exists: false },
+      })
+      .toArray()
+      .then((jobs) => {
+        const updates = jobs.map((jobData) => {
+          const job = new Job({
+            pulse: this,
+            name: jobData.name || '',
+            data: jobData.data || {},
+            type: jobData.type || 'normal',
+            priority: jobData.priority || 'normal',
+            shouldSaveResult: jobData.shouldSaveResult || false,
+            attempts: jobData.attempts || 0,
+            backoff: jobData.backoff,
+            ...jobData,
+          });
+
+          job.computeNextRunAt();
+
+          return this._collection.updateOne(
+            { _id: job.attrs._id },
+            {
+              $set: { nextRunAt: job.attrs.nextRunAt },
+              $unset: { lockedAt: undefined, lastModifiedBy: undefined, lastRunAt: undefined },
+            }
+          );
+        });
+
+        return Promise.all(updates);
+      })
+      .then((results) => {
+        const modifiedCount = results.filter((res) => res.modifiedCount > 0).length;
+        if (modifiedCount > 0) {
+          debug('Resumed %d recurring jobs (%s)', modifiedCount, now.toISOString());
         }
       });
   }

--- a/src/pulse/resume-on-restart.ts
+++ b/src/pulse/resume-on-restart.ts
@@ -51,7 +51,7 @@ export const resumeOnRestart: ResumeOnRestartMethod = function (this: Pulse, res
         }
       });
 
-    // Handling for recurring jobs using repeatInterval or repeatAt
+    // Recurring jobs
     this._collection
       .find({
         $and: [

--- a/test/unit/pulse.spec.ts
+++ b/test/unit/pulse.spec.ts
@@ -206,13 +206,17 @@ describe('Test Pulse', () => {
     });
 
     describe('Test resumeOnRestart', () => {
-      test('should enable resumeOnRestart by default', () => {
+      test('sets the default resumeOnRestart', () => {
         expect(globalPulseInstance._resumeOnRestart).toBeTruthy();
       });
 
-      test('should disable resumeOnRestart when set to false', () => {
+      test('sets the custom resumeOnRestart', () => {
         globalPulseInstance.resumeOnRestart(false);
         expect(globalPulseInstance._resumeOnRestart).toBeFalsy();
+      });
+
+      test('returns itself', () => {
+        expect(globalPulseInstance.resumeOnRestart(false)).toEqual(globalPulseInstance);
       });
 
       test('should not reschedule successfully finished non-recurring jobs', async () => {
@@ -305,14 +309,14 @@ describe('Test Pulse', () => {
         const job = globalPulseInstance.create('processData', { data: 'sample' });
         job.attrs.repeatInterval = '10 minutes';
         job.attrs.lockedAt = new Date();
-        job.attrs.nextRunAt = new Date(Date.now() + 10000); // Next run in 10 seconds
+        job.attrs.nextRunAt = new Date(Date.now() + 10000);
         await job.save();
 
         await globalPulseInstance.resumeOnRestart();
 
         const updatedJob = (await globalPulseInstance.jobs({ name: 'processData' }))[0];
-        expect(updatedJob.attrs.lockedAt).not.toBeNull(); // Job remains locked
-        expect(updatedJob.attrs.nextRunAt).not.toBeNull(); // Scheduling intact
+        expect(updatedJob.attrs.lockedAt).not.toBeNull();
+        expect(updatedJob.attrs.nextRunAt).not.toBeNull();
       });
 
       test('should handle interrupted recurring jobs after server recovery', async () => {
@@ -331,14 +335,14 @@ describe('Test Pulse', () => {
 
       test('should not modify non-recurring jobs with lastFinishedAt in the past', async () => {
         const job = globalPulseInstance.create('sendEmail', { to: 'user@example.com' });
-        job.attrs.lastFinishedAt = new Date(Date.now() - 10000); // Finished 10 seconds ago
+        job.attrs.lastFinishedAt = new Date(Date.now() - 10000);
         job.attrs.nextRunAt = null;
         await job.save();
 
         await globalPulseInstance.resumeOnRestart();
 
         const updatedJob = (await globalPulseInstance.jobs({ name: 'sendEmail' }))[0];
-        expect(updatedJob.attrs.nextRunAt).toBeNull(); // Job remains finished
+        expect(updatedJob.attrs.nextRunAt).toBeNull();
       });
     });
   });


### PR DESCRIPTION
Hi,

This PR hopes to solve some/all problems that have been flagged under these issues
- https://github.com/pulsecron/pulse/issues/57 - I have experienced it also
- https://github.com/pulsecron/pulse/issues/55 - I have experienced it also
- https://github.com/pulsecron/pulse/issues/54 - I have experienced it also

So, I'm proposing some changes to improve how `resumeOnRestart` works, ensure we’re handling all types of jobs correctly, and fix issues around rescheduling non-recurring jobs that shouldn’t be run again (on restart).

#### What’s Changed?

1. **Improved `resumeOnRestart`**
   - Non-recurring jobs:
     - Added a strong(er) check when searching for non-recurring jobs to search for both non-existent `lastFinishedAt` but also cover the case in which it is `null`
   - Recurring jobs:
     - Add proper search for the unfinished recurrent jobs and then reschedule them using the  `computeNextRunAt` function.

2. **Adjusted Job Model nextRunAt default** - If a non-recurring jobs is completed (`lastFinishedAt` exists), we should preserve the set `nextRunAt` (if it was set explicitly) and we should do not default it to `new Date()` (which triggers a re-run). For the recurrent jobs, we can keep what has been done before (either `nextRunAt` or `new Date()`).

3. **Added Test Cases** to check as much as we can if resumeOnRestart works properly

Let me know if you spot any edge cases or mistakes I need to fix.
