### PR TITLE
fix: revert changes to match 1.6.3, apart of resume on restart

### DIFF
--- a/src/job/index.ts
+++ b/src/job/index.ts
@@ -186,7 +186,7 @@ class Job<T extends JobAttributesData = JobAttributesData> {
   attrs: JobAttributes<T>;
 
   constructor(options: Modify<JobAttributes<T>, { _id?: mongodb.ObjectId }>) {
-    const { pulse, type, nextRunAt, repeatAt, repeatInterval, lastFinishedAt, ...args } = options ?? {};
+    const { pulse, type, nextRunAt, ...args } = options ?? {};
 
     // Save Pulse instance
     this.pulse = pulse;
@@ -211,7 +211,7 @@ class Job<T extends JobAttributesData = JobAttributesData> {
       ...attrs,
       name: attrs.name || '',
       priority: attrs.priority,
-      type: type || 'single',
+      type: type || 'once',
       // if a job that's non-recurring has a lastFinishedAt (finished the job), do not default nextRunAt to now
       // only if it will be defaulted either by explicitly setting it or by computing it computeNextRunAt
       nextRunAt: nextRunAt || new Date(),

--- a/test/unit/pulse.spec.ts
+++ b/test/unit/pulse.spec.ts
@@ -233,7 +233,7 @@ describe('Test Pulse', () => {
 
       test('should resume non-recurring jobs on restart', async () => {
         const job = globalPulseInstance.create('sendEmail', { to: 'user@example.com' });
-        job.attrs.nextRunAt = new Date(Date.now() - 1000);
+        job.attrs.nextRunAt = new Date(Date.now() - 2000);
         await job.save();
 
         await globalPulseInstance.resumeOnRestart();


### PR DESCRIPTION
@code-xhyun this is my last try to get 'nextRunAt` set on `null` fixed. 

As a note, on 1.6.3 - it works, `nextRunAt` gets set up correctly.

So 100% some of my changes are buggy.
With this change, I see no other differences between this and 1.6.3 - apart of the `resumeOnRestart` method which should not affect anything else.

So
- please take a look and see if we should change anything else. Ideally run it yourself also, maybe it's something wrong on my side.
- if you have no time - I am going to forward my apologize for the mistake(s) and I ask you to please revert all back to 1.6.3 which will keep all the original issues, but at least `nextRunAt` works as expected (tested myself). Like this we avoid making people use the buggy version.

I am sorry for this. Thank you.